### PR TITLE
Convert red to python 3

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -79,7 +79,7 @@ class Timetravel(Shortcut):
             <dim>(time travel)</dim> """))
 
         time = prompt(banner)
-        if not len(time):
+        if not time:
             return
 
         now = int(ctx['loc'].get('time') or 0)
@@ -125,7 +125,7 @@ class Print(Command):
 
     def run(self, execute, prompt, ctx):
         var = prompt(vt100.magenta(vt100.dim('(print) ')))
-        if not len(var):
+        if not var:
             return
         output = execute('print ' + var)
         return vt100.magenta(output)
@@ -198,7 +198,7 @@ class Custom(Command):
 
     def run(self, execute, prompt, ctx):
         command = prompt(vt100.dim('(odb) '))
-        if not len(command):
+        if not command:
             return
         output = execute(command)
         return vt100.blue('>> {0}\n'.format(command)) + output

--- a/red.py
+++ b/red.py
@@ -14,6 +14,7 @@ import inspect
 
 
 debugger_log = open('/tmp/red.log', 'w')
+
 def trace(text):
     debugger_log.write(text)
     debugger_log.flush()
@@ -116,7 +117,7 @@ def hl(src, breakpoint_lines):
         text = re.sub(a_ptrn, vt100.bold('\\1'), text)
         text = re.sub(b_ptrn, vt100.bold('\\1'), text)
 
-        symbol = u'\u2022' if has_breakpoint else ' '
+        symbol = '\u2022' if has_breakpoint else ' '
 
         # Can't use red twice, the closing color tag will mess the outputs
         if not is_current:
@@ -170,9 +171,10 @@ def main(args):
         return 1
 
     dbgr = subprocess.Popen(['ocamldebug', '-emacs'] + command_line,
+        encoding='utf-8',
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    print(debugger_command(dbgr, '')[0].replace('\tOCaml Debugger version ', vt100.red(u'\u2022 RED') + ' OCamlDebug v'))
+    print(debugger_command(dbgr, '')[0].replace('\tOCaml Debugger version ', vt100.red('\u2022 RED') + ' OCamlDebug v'))
     print(vt100.dim('Press ? for help'))
     print(debugger_command(dbgr, 'start')[0])
 
@@ -215,9 +217,9 @@ def repl(dbgr, console, auto_run):
         file_name = loc.get('file')
         listing = hl(execute('list'), breakpoint_lines_for_file(breakpoints, file_name))
         if listing:
-            console.print_text((u'\u2500[ %s ]' % loc.get('file')) + u'\u2500' * 300)
+            console.print_text(('\u2500[ %s ]' % loc.get('file')) + '\u2500' * 300)
             console.print_text(listing)
-            console.print_text(u'\u2500' * 300)
+            console.print_text('\u2500' * 300)
         else:
             module = loc.get('module')
             if module:

--- a/vt100.py
+++ b/vt100.py
@@ -72,7 +72,7 @@ class Console:
     def safe_input(self, prompt=None):
         self.lines_printed += 1
         try:
-            return raw_input(prompt)
+            return input(prompt)
         except:
             pass
 


### PR DESCRIPTION
Most of the changes are just related to python3 using unicode `str` and u8 `bytes` rather than u8 `str` and unicode `unicode`.

I also ran into some issues with `if not len(...)`; I was getting `None` in some cases, so I tweaked the conditions to trigger on either `None` or empty values.

With these changes I was able to use red against python3 on an ocaml project.